### PR TITLE
Fix __setitem__ with cython 3.2

### DIFF
--- a/src/sagemath_giac/giac.pyx
+++ b/src/sagemath_giac/giac.pyx
@@ -1011,10 +1011,10 @@ cdef class Pygen(GiacMethods_base):
         cdef gen v
         sig_on()
         cdef gen g = gen(<string>encstring23('GIACPY_TMP_NAME050268070969290100291003'),context_ptr)
-        GIAC_sto((<Pygen>self).gptr[0],g,1,context_ptr)
+        GIAC_sto((<Pygen>self).gptr[0],g,True,context_ptr)
         g = gen(<string>encstring23('GIACPY_TMP_NAME050268070969290100291003[%s]' % str(key)), context_ptr)
         v=(<Pygen>(Pygen(value).eval())).gptr[0]
-        GIAC_sto(v, g, 1, context_ptr)
+        GIAC_sto(v, g, True, context_ptr)
         Pygen('purge(GIACPY_TMP_NAME050268070969290100291003):;').eval()
         sig_off()
         return


### PR DESCRIPTION
In cython 3.2 `1` is not accepted as a bool.

Fixes https://github.com/sagemath/sagemath-giac/issues/5